### PR TITLE
New Bot Event State Logging

### DIFF
--- a/SDGDiscordBot.js
+++ b/SDGDiscordBot.js
@@ -43,12 +43,28 @@ MongoClient.connect("mongodb://localhost:27017/shamebotdb", function(err, databa
 winstonModule.createWinstonFileTransport();
 
 bot.on("disconnected", () => {
-	winston.info("** Shamebot disconnected at " + new Date() + " **");
+  ServerLog.botConnectionStatus('disconnected');
 });
 
 bot.on("ready", () => {
-	winston.info("|| -- Shamebot ready for input at " + new Date() + " -- ||");
+  ServerLog.botConnectionStatus('ready');
   bot.user.setPresence({ game: { name: "with Shame", type: 0 } });
+});
+
+bot.on("resume", () => {
+  ServerLog.botConnectionStatus('resuming');
+});
+
+bot.on("reconnecting", () => {
+  ServerLog.botConnectionStatus('reconnecting');
+});
+
+bot.on("warn", (warning) => {
+	winston.info("+| Warning: " + warning + " |+");
+});
+
+bot.on("error", (error) => {
+	winston.info("*|| Error: " + error + " ||*");
 });
 
 bot.on("message", message => {

--- a/modules/serverLogModule.js
+++ b/modules/serverLogModule.js
@@ -131,6 +131,16 @@ var ServerLogManager = function (bot){
     .catch((err) => winston.error("couldn't send new channel message info:", err));
   }
 
+  this.botConnectionStatus = function (statusMessage) {
+    var serverLogChannel = bot.channels.find("name", "serverlog");
+
+    var message = "** Shamebot " + statusMessage + " at " + new Date() + " **"
+    winston.info(message);
+
+    serverLogChannel.send(message)
+    .catch((err) => winston.error("couldn't send new channel message info:", err));
+  }
+
 }
 
 module.exports = ServerLogManager;


### PR DESCRIPTION
With one of the recent updates some new event states were added.
Wanted to take the chance to standardize some of the logging and put
it in a channel

Example of logging output. 
`info: ** Shamebot ready at Wed Jan 31 2018 12:49:31 GMT-0500 (EST) **
info: ** Shamebot reconnecting at Wed Jan 31 2018 12:53:57 GMT-0500 (EST) **
error: couldn't send new channel message info: Error: connect EHOSTDOWN 104.16.59.5:443 - Local (0.0.0.0:0)
    at Object._errnoException (util.js:1031:13)
    at _exceptionWithHostPort (util.js:1052:20)
    at internalConnect (net.js:977:16)
    at GetAddrInfoReqWrap.emitLookup [as callback] (net.js:1119:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:102:10)
(node:5705) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Converting circular structure to JSON
(node:5705) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
info: ** Shamebot resuming at Wed Jan 31 2018 12:54:03 GMT-0500 (EST) **`

This actually works out as it will send the message once it reconnects (yay promises) and the deprecation warning should go away in an upcoming version.

Example in server:
<img width="476" alt="screen shot 2018-01-31 at 1 02 19 pm" src="https://user-images.githubusercontent.com/914013/35639086-02c40972-0687-11e8-9e34-021497e5780f.png">
