### PR TITLE
Copy Pasta error for Updated Server role variable reference

### DIFF
--- a/modules/serverLogModule.js
+++ b/modules/serverLogModule.js
@@ -119,10 +119,10 @@ var ServerLogManager = function (bot){
     serverLogChannel.send('**Updated Server Role**\n' +
     'The ' + originalRole.name + ' server role was updated.' +
     '\n**Original Role:** \t' + originalRole.name +
-    '\n\tName: ' + deletedServerRole.name +
-    '\n\tID: ' + deletedServerRole.id +
-    '\n\tColor: ' + deletedServerRole.hexColor +
-    '\n\tCreation Date: ' + deletedServerRole.createdAt +
+    '\n\tName: ' + originalRole.name +
+    '\n\tID: ' + originalRole.id +
+    '\n\tColor: ' + originalRole.hexColor +
+    '\n\tCreation Date: ' + originalRole.createdAt +
     '\n**Updated Role:** \t' + updatedRole.name +
     '\n\tName: ' + updatedRole.name +
     '\n\tID: ' + updatedRole.id +


### PR DESCRIPTION
deleted role should have been original role.

This is why boilerplate copy pasta sucks! Mental note to just refactor it all away


Stacktrace:
`ReferenceError: deletedServerRole is not defined
    at ServerLogManager.serverRoleUpdatedEvent (/SDG_Discord_Bot/modules/serverLogModule.js:122:20)
    at Client. (/SDG_Discord_Bot/SDGDiscordBot.js:457:13)
    at emitTwo (events.js:106:13)
    at Client.emit (events.js:192:7)
    at GuildRoleUpdateAction.handle (/SDG_Discord_Bot/node_modules/discord.js/src/client/actions/GuildRoleUpdate.js:18:16)
    at GuildRoleUpdateHandler.handle (/SDG_Discord_Bot/node_modules/discord.js/src/client/websocket/packets/handlers/GuildRoleUpdate.js:7:36)`